### PR TITLE
fix: Update `name` assignment and remove name getter method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "27.0.2",
-        "graphql": "15.7.1",
+        "graphql": "15.7.2",
         "jest": "27.3.1",
         "prettier": "2.4.1",
         "ts-jest": "27.0.7",
@@ -1936,9 +1936,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.1.tgz",
-      "integrity": "sha512-x34S6gC0/peBZnlK60zCJox/d45A7p6At9oN9EPA3qhoIAlR4LNZmXRLkICBckwwTMJzVdA8cx3QIQZMOl606A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -5588,9 +5588,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.1.tgz",
-      "integrity": "sha512-x34S6gC0/peBZnlK60zCJox/d45A7p6At9oN9EPA3qhoIAlR4LNZmXRLkICBckwwTMJzVdA8cx3QIQZMOl606A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
       "dev": true
     },
     "has": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "27.0.2",
-        "graphql": "15.7.2",
+        "graphql": "15.7.1",
         "jest": "27.3.1",
         "prettier": "2.4.1",
         "ts-jest": "27.0.7",
@@ -20,7 +20,7 @@
         "node": ">=12.13.0 <17.0"
       },
       "peerDependencies": {
-        "graphql": "^14.5.0 || ^15.0.0"
+        "graphql": "^15.7.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1936,9 +1936,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
-      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.1.tgz",
+      "integrity": "sha512-x34S6gC0/peBZnlK60zCJox/d45A7p6At9oN9EPA3qhoIAlR4LNZmXRLkICBckwwTMJzVdA8cx3QIQZMOl606A==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -5588,9 +5588,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
-      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.1.tgz",
+      "integrity": "sha512-x34S6gC0/peBZnlK60zCJox/d45A7p6At9oN9EPA3qhoIAlR4LNZmXRLkICBckwwTMJzVdA8cx3QIQZMOl606A==",
       "dev": true
     },
     "has": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@apollo/core-schema",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "27.0.2",
-        "graphql": "15.6.1",
+        "graphql": "15.7.2",
         "jest": "27.3.1",
         "prettier": "2.4.1",
         "ts-jest": "27.0.7",
@@ -1936,9 +1936,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz",
-      "integrity": "sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -5588,9 +5588,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz",
-      "integrity": "sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
       "dev": true
     },
     "has": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.0.2",
-    "graphql": "15.6.1",
+    "graphql": "15.7.2",
     "jest": "27.3.1",
     "prettier": "2.4.1",
     "ts-jest": "27.0.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.0.2",
-    "graphql": "15.7.1",
+    "graphql": "15.7.2",
     "jest": "27.3.1",
     "prettier": "2.4.1",
     "ts-jest": "27.0.7",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "graphql": "^14.5.0 || ^15.0.0"
+    "graphql": "^15.7.2"
   },
   "devDependencies": {
     "@types/jest": "27.0.2",
-    "graphql": "15.7.2",
+    "graphql": "15.7.1",
     "jest": "27.3.1",
     "prettier": "2.4.1",
     "ts-jest": "27.0.7",

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -1,0 +1,8 @@
+import { ErrCheckFailed } from "../core";
+
+describe("GraphQLErrorExt", () => {
+  it("correctly self-assigns its name property", () => {
+    const error = ErrCheckFailed([]);
+    expect(error.name).toEqual("CheckFailed");
+  });
+});

--- a/src/error.ts
+++ b/src/error.ts
@@ -15,6 +15,8 @@ export type Props = {
 export class GraphQLErrorExt<C extends string> extends GraphQLError {
   static readonly BASE_PROPS = new Set('nodes source positions path originalError extensions'.split(' '))
 
+  readonly name: string;
+
   constructor(public readonly code: C, message: string, props?: Props) {
     super(message,
       props?.nodes,
@@ -29,8 +31,9 @@ export class GraphQLErrorExt<C extends string> extends GraphQLError {
         (this as any)[prop] = (props as any)[prop]
       }
     }
+
+    this.name = code;
   }
-  get name() { return this.code }
 
   throw(): never { throw this }
   toString() {


### PR DESCRIPTION
The `get name()` getter on the `GraphQLErrorExt` class is broken by the latest releases of `graphql-js` (`^15.7.0`). This adjusts the current path of name assignment to match the new way that it's done in the latest versions of `graphql-js`.