### PR TITLE
fix: Don't call `GraphQLError.toString()` recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing to see here. Stay tuned._
+- Don't call `GraphQLError.toString()` recursively [PR #36](https://github.com/apollographql/core-schema-js/pull/36)
 
 ## v0.2.1
 

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -1,8 +1,21 @@
 import { ErrCheckFailed } from "../core";
+import { GraphQLErrorExt } from "../error";
 
 describe("GraphQLErrorExt", () => {
   it("correctly self-assigns its name property", () => {
     const error = ErrCheckFailed([]);
     expect(error.name).toEqual("CheckFailed");
+  });
+
+  it("calling `toString` doesn't throw an error", () => {
+    const error = new GraphQLErrorExt("CheckFailed", "Check failed");
+    expect(() => error.toString()).not.toThrow();
+  });
+
+  it("calling `toString` prints the error", () => {
+    const error = new GraphQLErrorExt("CheckFailed", "Check failed");
+    expect(error.toString()).toMatchInlineSnapshot(
+      `"[CheckFailed] Check failed"`
+    );
   });
 });

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,73 +1,111 @@
-import { ASTNode, GraphQLError, printError, Source } from 'graphql'
-import { Maybe } from 'graphql/jsutils/Maybe'
+import {
+  ASTNode,
+  GraphQLError,
+  printLocation,
+  printSourceLocation,
+  Source,
+} from "graphql";
+import { Maybe } from "graphql/jsutils/Maybe";
 
 export type Props = {
-  message: string,
-  nodes?: Maybe<ReadonlyArray<ASTNode> | ASTNode>,
-  source?: Maybe<Source>,
-  positions?: Maybe<ReadonlyArray<number>>,
-  path?: Maybe<ReadonlyArray<string | number>>,
-  originalError?: Maybe<Error>,
-  extensions?: Maybe<{ [key: string]: any }>,
-  causes?: Error[]
-}
+  message: string;
+  nodes?: Maybe<ReadonlyArray<ASTNode> | ASTNode>;
+  source?: Maybe<Source>;
+  positions?: Maybe<ReadonlyArray<number>>;
+  path?: Maybe<ReadonlyArray<string | number>>;
+  originalError?: Maybe<Error>;
+  extensions?: Maybe<{ [key: string]: any }>;
+  causes?: Error[];
+};
 
 export class GraphQLErrorExt<C extends string> extends GraphQLError {
-  static readonly BASE_PROPS = new Set('nodes source positions path originalError extensions'.split(' '))
+  static readonly BASE_PROPS = new Set(
+    "nodes source positions path originalError extensions".split(" ")
+  );
 
   readonly name: string;
 
   constructor(public readonly code: C, message: string, props?: Props) {
-    super(message,
+    super(
+      message,
       props?.nodes,
       props?.source,
       props?.positions,
       props?.path,
       props?.originalError,
       props?.extensions
-    )
-    if (props) for (const prop in props) {
-      if (!GraphQLErrorExt.BASE_PROPS.has(prop)) {
-        (this as any)[prop] = (props as any)[prop]
+    );
+    if (props)
+      for (const prop in props) {
+        if (!GraphQLErrorExt.BASE_PROPS.has(prop)) {
+          (this as any)[prop] = (props as any)[prop];
+        }
       }
-    }
 
     this.name = code;
   }
 
-  throw(): never { throw this }
-  toString() {
-    let output = `[${this.code}] ${printError(this as any)}`
-    const causes = (this as any).causes
+  throw(): never {
+    throw this;
+  }
+  toString(): string {
+    let output = `[${this.code}] ${this.printOriginalError(this)}`;
+    const causes = (this as any).causes;
     if (causes && causes.length) {
-      output += '\ncaused by:'
+      output += "\ncaused by:";
       for (const cause of (this as any).causes || []) {
-        if (!cause) continue
-        output += '\n\n  - '
-        output += cause.toString().split('\n').join('\n    ')
+        if (!cause) continue;
+        output += "\n\n  - ";
+        output += cause.toString().split("\n").join("\n    ");
       }
     }
 
-    return output
+    return output;
+  }
+
+  // The previous implementation of `printError`, now `GraphQLError.toString()`
+  printOriginalError(err: GraphQLError) {
+    let output = err.message;
+
+    if (err.nodes) {
+      for (const node of err.nodes) {
+        if (node.loc) {
+          output += "\n\n" + printLocation(node.loc);
+        }
+      }
+    } else if (err.source && err.locations) {
+      for (const location of err.locations) {
+        output += "\n\n" + printSourceLocation(err.source, location);
+      }
+    }
+
+    return output;
   }
 }
 
 /**
  * Return a GraphQLError with a code and arbitrary set of properties.
- * 
+ *
  * This mainly helps deal with the very long list of parameters that GraphQLError's constructor
  * can take. It also ensures that all errors have a code, and provides a return typing that
  * facilitates extracting the provided props based on the code, as TypeScript will consider a union of
  * these errors to be a tagged union.
- * 
- * @param code 
- * @param props 
- * @returns 
+ *
+ * @param code
+ * @param props
+ * @returns
  */
-export function err<C extends string, P extends Props>(code: C, props: P | string): GraphQLErrorExt<C> & P {
-  const message = typeof props === 'string' ? props : props.message  
-  const error = new GraphQLErrorExt(code, message, typeof props === 'string' ? undefined : props)
-  return error as any
+export function err<C extends string, P extends Props>(
+  code: C,
+  props: P | string
+): GraphQLErrorExt<C> & P {
+  const message = typeof props === "string" ? props : props.message;
+  const error = new GraphQLErrorExt(
+    code,
+    message,
+    typeof props === "string" ? undefined : props
+  );
+  return error as any;
 }
 
-export default err
+export default err;

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,10 +1,4 @@
-import {
-  ASTNode,
-  GraphQLError,
-  printLocation,
-  printSourceLocation,
-  Source,
-} from "graphql";
+import { ASTNode, GraphQLError, Source } from "graphql";
 import { Maybe } from "graphql/jsutils/Maybe";
 
 export type Props = {
@@ -48,8 +42,9 @@ export class GraphQLErrorExt<C extends string> extends GraphQLError {
   throw(): never {
     throw this;
   }
+
   toString(): string {
-    let output = `[${this.code}] ${this.printOriginalError(this)}`;
+    let output = `[${this.code}] ${super.toString()}`;
     const causes = (this as any).causes;
     if (causes && causes.length) {
       output += "\ncaused by:";
@@ -57,25 +52,6 @@ export class GraphQLErrorExt<C extends string> extends GraphQLError {
         if (!cause) continue;
         output += "\n\n  - ";
         output += cause.toString().split("\n").join("\n    ");
-      }
-    }
-
-    return output;
-  }
-
-  // The previous implementation of `printError`, now `GraphQLError.toString()`
-  printOriginalError(err: GraphQLError) {
-    let output = err.message;
-
-    if (err.nodes) {
-      for (const node of err.nodes) {
-        if (node.loc) {
-          output += "\n\n" + printLocation(node.loc);
-        }
-      }
-    } else if (err.source && err.locations) {
-      for (const location of err.locations) {
-        output += "\n\n" + printSourceLocation(err.source, location);
       }
     }
 


### PR DESCRIPTION
`graphql@16` deprecated `printError`, which now calls `error.toString()`. Our `GraphQLErrorExt` class calls this within its own `toString()` method, causing a "call stack exceeded" infinite recursive loop.