### PR TITLE
add a `Schema.surface` method which removes external definitions

### DIFF
--- a/src/__tests__/de.test.ts
+++ b/src/__tests__/de.test.ts
@@ -62,45 +62,87 @@ describe("fill", () => {
         Array [
           "NoDefinition",
           Array [
-            [example] 👉@link(url: "https://specs.apollo.dev/federation/v2.0",
+            Object {
+              "gref": GRef <https://specs.apollo.dev/federation/v2.0#@requires>,
+              "message": "no definitions found for reference: https://specs.apollo.dev/federation/v2.0#@requires",
+              "nodes": Array [
+                [example] 👉@link(url: "https://specs.apollo.dev/federation/v2.0",
+              ],
+            },
           ],
         ],
         Array [
           "NoDefinition",
           Array [
-            [example] 👉@link(url: "https://specs.apollo.dev/federation/v2.0",
+            Object {
+              "gref": GRef <https://specs.apollo.dev/federation/v2.0#@provides>,
+              "message": "no definitions found for reference: https://specs.apollo.dev/federation/v2.0#@provides",
+              "nodes": Array [
+                [example] 👉@link(url: "https://specs.apollo.dev/federation/v2.0",
+              ],
+            },
           ],
         ],
         Array [
           "NoDefinition",
           Array [
-            <https://specs/me#ID>[example] id: 👉ID!,
+            Object {
+              "gref": GRef <https://specs/me#ID>,
+              "message": "no definitions found for reference: https://specs/me#ID",
+              "nodes": Array [
+                <https://specs/me#ID>[example] id: 👉ID!,
+              ],
+            },
           ],
         ],
         Array [
           "NoDefinition",
           Array [
-            <https://specs/me#String>[example] directive @key(fields: 👉String) on OBJECT,
+            Object {
+              "gref": GRef <https://specs/me#String>,
+              "message": "no definitions found for reference: https://specs/me#String",
+              "nodes": Array [
+                <https://specs/me#String>[example] directive @key(fields: 👉String) on OBJECT,
+              ],
+            },
           ],
         ],
         Array [
           "NoDefinition",
           Array [
-            <https://specs.apollo.dev/link/v1.0#Url>[builtins.graphql] directive @id(url: 👉link__Url!, as: link__Schema) on SCHEMA,
-            <https://specs.apollo.dev/link/v1.0#Url>[builtins.graphql] directive @link(url: 👉link__Url!, as: link__Schema, import: link__Import),
+            Object {
+              "gref": GRef <https://specs.apollo.dev/link/v1.0#Url>,
+              "message": "no definitions found for reference: https://specs.apollo.dev/link/v1.0#Url",
+              "nodes": Array [
+                <https://specs.apollo.dev/link/v1.0#Url>[builtins.graphql] directive @id(url: 👉link__Url!, as: link__Schema) on SCHEMA,
+                <https://specs.apollo.dev/link/v1.0#Url>[builtins.graphql] directive @link(url: 👉link__Url!, as: link__Schema, import: link__Import),
+              ],
+            },
           ],
         ],
         Array [
           "NoDefinition",
           Array [
-            <https://specs.apollo.dev/link/v1.0#Schema>[builtins.graphql] directive @id(url: link__Url!, as: 👉link__Schema) on SCHEMA,
-            <https://specs.apollo.dev/link/v1.0#Schema>[builtins.graphql] directive @link(url: link__Url!, as: 👉link__Schema, import: link__Import),
+            Object {
+              "gref": GRef <https://specs.apollo.dev/link/v1.0#Schema>,
+              "message": "no definitions found for reference: https://specs.apollo.dev/link/v1.0#Schema",
+              "nodes": Array [
+                <https://specs.apollo.dev/link/v1.0#Schema>[builtins.graphql] directive @id(url: link__Url!, as: 👉link__Schema) on SCHEMA,
+                <https://specs.apollo.dev/link/v1.0#Schema>[builtins.graphql] directive @link(url: link__Url!, as: 👉link__Schema, import: link__Import),
+              ],
+            },
           ],
         ],
         Array [
           "NoDefinition",
           Array [
-            <https://specs.apollo.dev/link/v1.0#Import>[builtins.graphql] directive @link(url: link__Url!, as: link__Schema, import: 👉link__Import),
+            Object {
+              "gref": GRef <https://specs.apollo.dev/link/v1.0#Import>,
+              "message": "no definitions found for reference: https://specs.apollo.dev/link/v1.0#Import",
+              "nodes": Array [
+                <https://specs.apollo.dev/link/v1.0#Import>[builtins.graphql] directive @link(url: link__Url!, as: link__Schema, import: 👉link__Import),
+              ],
+            },
           ],
         ],
       ]
@@ -213,27 +255,9 @@ describe("a subgraph test", () => {
       )
     ).toMatchInlineSnapshot(`
       Array [
-        [NoDefinition] no definitions found for reference: https://specs.apollo.dev/federation/v1.0#@requires
-
-      subgraph-test.graphql:4:9
-      3 |         @link(url: "https://specs.apollo.dev/link/v1.0")
-      4 |         @link(url: "https://specs.apollo.dev/federation/v1.0",
-        |         ^
-      5 |           import: "@key @requires @provides @external"),
-        [NoDefinition] no definitions found for reference: https://specs.apollo.dev/federation/v1.0#@provides
-
-      subgraph-test.graphql:4:9
-      3 |         @link(url: "https://specs.apollo.dev/link/v1.0")
-      4 |         @link(url: "https://specs.apollo.dev/federation/v1.0",
-        |         ^
-      5 |           import: "@key @requires @provides @external"),
-        [NoDefinition] no definitions found for reference: https://specs.apollo.dev/federation/v1.0#@external
-
-      subgraph-test.graphql:4:9
-      3 |         @link(url: "https://specs.apollo.dev/link/v1.0")
-      4 |         @link(url: "https://specs.apollo.dev/federation/v1.0",
-        |         ^
-      5 |           import: "@key @requires @provides @external"),
+        [NoDefinition] no definitions found for reference: https://specs.apollo.dev/federation/v1.0#@requires,
+        [NoDefinition] no definitions found for reference: https://specs.apollo.dev/federation/v1.0#@provides,
+        [NoDefinition] no definitions found for reference: https://specs.apollo.dev/federation/v1.0#@external,
       ]
     `);
   });

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -7,6 +7,7 @@ import Schema from "../schema";
 import { Atlas } from "../atlas";
 import raw from "../snapshot-serializers/raw";
 import { getResult } from "@protoplasm/recall";
+import supergraph from "./supergraph";
 
 const base = Schema.from(
   parse(
@@ -268,7 +269,13 @@ describe("Schema", () => {
         Array [
           [NoDefinition: no definitions found for reference: #SomeUnresolvedType],
           Array [
-            <#SomeUnresolvedType>[subgraph] field: 👉SomeUnresolvedType,
+            Object {
+              "gref": GRef <#SomeUnresolvedType>,
+              "message": "no definitions found for reference: #SomeUnresolvedType",
+              "nodes": Array [
+                <#SomeUnresolvedType>[subgraph] field: 👉SomeUnresolvedType,
+              ],
+            },
           ],
         ],
       ]
@@ -638,6 +645,250 @@ describe("Schema", () => {
         field: Foo
       }"
     `);
+  });
+
+  describe("extracting api surface", () => {
+    it("extracts api surface", () => {
+      expect(raw(Schema.from(supergraph).surface().print()))
+        .toMatchInlineSnapshot(`
+        schema {
+          query: Query
+        }
+
+        type DeliveryEstimates {
+          estimatedDelivery: String
+          fastestDelivery: String
+        }
+
+        type Panda {
+          name: ID!
+          favoriteFood: String
+        }
+
+        type Product implements ProductItf & SkuItf {
+          id: ID!
+          dimensions: ProductDimension
+          delivery(zip: String): DeliveryEstimates
+          sku: String
+          package: String
+          variation: ProductVariation
+          createdBy: User
+        }
+
+        type ProductDimension {
+          size: String
+          weight: Float
+        }
+
+        interface ProductItf implements SkuItf {
+          id: ID!
+          dimensions: ProductDimension
+          delivery(zip: String): DeliveryEstimates
+          sku: String
+          package: String
+          variation: ProductVariation
+          createdBy: User
+        }
+
+        type ProductVariation {
+          id: ID!
+        }
+
+        type Query {
+          allPandas: [Panda]
+          panda(name: ID!): Panda
+          allProducts: [ProductItf]
+          product(id: ID!): ProductItf
+        }
+
+        enum ShippingClass {
+          STANDARD
+          EXPRESS
+          OVERNIGHT
+        }
+
+        interface SkuItf {
+          sku: String
+        }
+
+        type User {
+          email: ID!
+          totalProductsCreated: Int
+          name: String
+        }
+      `);
+    });
+
+    it("retains specified links", () => {
+      expect(
+        raw(
+          Schema.from(supergraph)
+            .surface(["https://specs.apollo.dev/join/v0.2"])
+            .print()
+        )
+      ).toMatchInlineSnapshot(`
+        schema {
+          query: Query
+        }
+
+        directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+        directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+        directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+        directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+        type DeliveryEstimates @join__type(graph: INVENTORY) {
+          estimatedDelivery: String
+          fastestDelivery: String
+        }
+
+        scalar join__FieldSet
+
+        enum join__Graph {
+          INVENTORY @join__graph(name: "inventory", url: "http://inventory:4000/graphql")
+          PANDAS @join__graph(name: "pandas", url: "http://pandas:4000/graphql")
+          PRODUCTS @join__graph(name: "products", url: "http://products:4000/graphql")
+          USERS @join__graph(name: "users", url: "http://users:4000/graphql")
+        }
+
+        type Panda @join__type(graph: PANDAS) {
+          name: ID!
+          favoriteFood: String
+        }
+
+        type Product implements ProductItf & SkuItf @join__implements(graph: INVENTORY, interface: "ProductItf") @join__implements(graph: PRODUCTS, interface: "ProductItf") @join__implements(graph: PRODUCTS, interface: "SkuItf") @join__type(graph: INVENTORY, key: "id") @join__type(graph: PRODUCTS, key: "id") @join__type(graph: PRODUCTS, key: "sku package") @join__type(graph: PRODUCTS, key: "sku variation { id }") {
+          id: ID!
+          dimensions: ProductDimension @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+          delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
+          sku: String @join__field(graph: PRODUCTS)
+          package: String @join__field(graph: PRODUCTS)
+          variation: ProductVariation @join__field(graph: PRODUCTS)
+          createdBy: User @join__field(graph: PRODUCTS)
+        }
+
+        type ProductDimension @join__type(graph: INVENTORY) @join__type(graph: PRODUCTS) {
+          size: String
+          weight: Float
+        }
+
+        interface ProductItf implements SkuItf @join__implements(graph: PRODUCTS, interface: "SkuItf") @join__type(graph: INVENTORY) @join__type(graph: PRODUCTS) {
+          id: ID!
+          dimensions: ProductDimension
+          delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY)
+          sku: String @join__field(graph: PRODUCTS)
+          package: String @join__field(graph: PRODUCTS)
+          variation: ProductVariation @join__field(graph: PRODUCTS)
+          createdBy: User @join__field(graph: PRODUCTS)
+        }
+
+        type ProductVariation @join__type(graph: PRODUCTS) {
+          id: ID!
+        }
+
+        type Query @join__type(graph: INVENTORY) @join__type(graph: PANDAS) @join__type(graph: PRODUCTS) @join__type(graph: USERS) {
+          allPandas: [Panda] @join__field(graph: PANDAS)
+          panda(name: ID!): Panda @join__field(graph: PANDAS)
+          allProducts: [ProductItf] @join__field(graph: PRODUCTS)
+          product(id: ID!): ProductItf @join__field(graph: PRODUCTS)
+        }
+
+        enum ShippingClass @join__type(graph: INVENTORY) @join__type(graph: PRODUCTS) {
+          STANDARD
+          EXPRESS
+          OVERNIGHT
+        }
+
+        interface SkuItf @join__type(graph: PRODUCTS) {
+          sku: String
+        }
+
+        type User @join__type(graph: PRODUCTS, key: "email") @join__type(graph: USERS, key: "email") {
+          email: ID!
+          totalProductsCreated: Int
+          name: String @join__field(graph: USERS)
+        }
+      `);
+    });
+
+    it("retains specified directives", () => {
+      expect(
+        raw(
+          Schema.from(supergraph)
+            .surface([GRef.rootDirective("https://specs.apollo.dev/tag/v0.2")])
+            .print()
+        )
+      ).toMatchInlineSnapshot(`
+        schema {
+          query: Query
+        }
+
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        type DeliveryEstimates {
+          estimatedDelivery: String
+          fastestDelivery: String
+        }
+
+        type Panda {
+          name: ID!
+          favoriteFood: String @tag(name: "nom-nom-nom")
+        }
+
+        type Product implements ProductItf & SkuItf {
+          id: ID! @tag(name: "hi-from-products")
+          dimensions: ProductDimension
+          delivery(zip: String): DeliveryEstimates
+          sku: String
+          package: String
+          variation: ProductVariation
+          createdBy: User
+        }
+
+        type ProductDimension {
+          size: String
+          weight: Float
+        }
+
+        interface ProductItf implements SkuItf {
+          id: ID!
+          dimensions: ProductDimension
+          delivery(zip: String): DeliveryEstimates
+          sku: String
+          package: String
+          variation: ProductVariation
+          createdBy: User
+        }
+
+        type ProductVariation {
+          id: ID!
+        }
+
+        type Query {
+          allPandas: [Panda]
+          panda(name: ID!): Panda
+          allProducts: [ProductItf]
+          product(id: ID!): ProductItf
+        }
+
+        enum ShippingClass {
+          STANDARD
+          EXPRESS
+          OVERNIGHT
+        }
+
+        interface SkuItf {
+          sku: String
+        }
+
+        type User {
+          email: ID! @tag(name: "test-from-users")
+          totalProductsCreated: Int
+          name: String
+        }
+      `);
+    });
   });
 });
 

--- a/src/__tests__/supergraph.ts
+++ b/src/__tests__/supergraph.ts
@@ -1,0 +1,142 @@
+import gql from '../gql'
+
+export default gql `
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/tag/v0.2")
+{
+  query: Query
+}
+
+directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+type DeliveryEstimates
+  @join__type(graph: INVENTORY)
+{
+  estimatedDelivery: String
+  fastestDelivery: String
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory:4000/graphql")
+  PANDAS @join__graph(name: "pandas", url: "http://pandas:4000/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products:4000/graphql")
+  USERS @join__graph(name: "users", url: "http://users:4000/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  EXECUTION features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Panda
+  @join__type(graph: PANDAS)
+{
+  name: ID!
+  favoriteFood: String @tag(name: "nom-nom-nom")
+}
+
+type Product implements ProductItf & SkuItf
+  @join__implements(graph: INVENTORY, interface: "ProductItf")
+  @join__implements(graph: PRODUCTS, interface: "ProductItf")
+  @join__implements(graph: PRODUCTS, interface: "SkuItf")
+  @join__type(graph: INVENTORY, key: "id")
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__type(graph: PRODUCTS, key: "sku package")
+  @join__type(graph: PRODUCTS, key: "sku variation { id }")
+{
+  id: ID! @tag(name: "hi-from-products")
+  dimensions: ProductDimension @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
+  sku: String @join__field(graph: PRODUCTS)
+  package: String @join__field(graph: PRODUCTS)
+  variation: ProductVariation @join__field(graph: PRODUCTS)
+  createdBy: User @join__field(graph: PRODUCTS)
+}
+
+type ProductDimension
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+{
+  size: String
+  weight: Float
+}
+
+interface ProductItf implements SkuItf
+  @join__implements(graph: PRODUCTS, interface: "SkuItf")
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+{
+  id: ID!
+  dimensions: ProductDimension
+  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY)
+  sku: String @join__field(graph: PRODUCTS)
+  package: String @join__field(graph: PRODUCTS)
+  variation: ProductVariation @join__field(graph: PRODUCTS)
+  createdBy: User @join__field(graph: PRODUCTS)
+}
+
+type ProductVariation
+  @join__type(graph: PRODUCTS)
+{
+  id: ID!
+}
+
+type Query
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PANDAS)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: USERS)
+{
+  allPandas: [Panda] @join__field(graph: PANDAS)
+  panda(name: ID!): Panda @join__field(graph: PANDAS)
+  allProducts: [ProductItf] @join__field(graph: PRODUCTS)
+  product(id: ID!): ProductItf @join__field(graph: PRODUCTS)
+}
+
+enum ShippingClass
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+{
+  STANDARD
+  EXPRESS
+  OVERNIGHT
+}
+
+interface SkuItf
+  @join__type(graph: PRODUCTS)
+{
+  sku: String
+}
+
+type User
+  @join__type(graph: PRODUCTS, key: "email")
+  @join__type(graph: USERS, key: "email")
+{
+  email: ID! @tag(name: "test-from-users")
+  totalProductsCreated: Int
+  name: String @join__field(graph: USERS)
+}
+`

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -25,4 +25,8 @@ export const directives = replay(
   }
 )
 
+export function hasDirectives(o: any): o is HasDirectives {
+  return Array.isArray(o?.directives)
+}
+
 export default directives

--- a/src/error.ts
+++ b/src/error.ts
@@ -20,7 +20,7 @@ export class GraphQLErrorExt<C extends string> extends GraphQLError {
   readonly name: string;
 
   constructor(public readonly code: C, message: string, props?: Props) {
-    super(message, props)
+    super(message, props as any)
     if (props) for (const prop in props)
       if (!GraphQLErrorExt.BASE_PROPS.has(prop)) {
         (this as any)[prop] = (props as any)[prop]

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,5 @@
 import recall, { replay, use } from '@protoplasm/recall'
-import { print, DirectiveNode, DocumentNode, Kind, SchemaDefinitionNode, visit } from 'graphql'
+import { print, DirectiveNode, DocumentNode, Kind, SchemaDefinitionNode, visit, DefinitionNode } from 'graphql'
 import { Maybe } from 'graphql/jsutils/Maybe'
 import { refNodesIn, Defs, isLocatable, Locatable, fill, Def, isRedirect } from './de'
 import { id, Link, Linker, LINK_DIRECTIVES } from './linker'
@@ -10,7 +10,15 @@ import { isAst } from './is'
 import gql from './gql'
 import LinkUrl from './link-url'
 import {concat} from './each'
-export class Schema implements Defs {  
+export class Schema implements Defs {
+  @use(recall)
+  static fromDefinitions(defs: Iterable<DefinitionNode>, frame: Schema | IScope = Scope.EMPTY) {
+    return this.from({
+      kind: Kind.DOCUMENT,
+      definitions: [...defs]
+    }, frame)
+  }
+  
   static from(document: DocumentNode, frame: Schema | IScope = Scope.EMPTY) {
     if (frame instanceof Schema)
       return new this(document, frame.scope)


### PR DESCRIPTION
this PR introduces the `Schema.surface` method. `.surface(retain?)` removes all external definitions except those you tell it to retain. it does not handle removing `@inaccessible`, but can be used prior to an inaccessible removal step.

(note that if the intention is to use this prior to removing `@inaccessible`, you should probably retain`@inaccessible` ;) )